### PR TITLE
Add support for testing invalid inputs in benchmarks and generate malformed data

### DIFF
--- a/benchmarks/benchmark.cpp
+++ b/benchmarks/benchmark.cpp
@@ -62,7 +62,7 @@
 #endif
 
 template <typename CharT>
-double findmax_doubleconversion(std::vector<std::basic_string<CharT>> &s) {
+double findmax_doubleconversion(std::vector<std::basic_string<CharT>> &s, bool expect_error) {
   double answer = 0;
   double x;
   // from_chars does not allow leading spaces:
@@ -81,7 +81,7 @@ double findmax_doubleconversion(std::vector<std::basic_string<CharT>> &s) {
     } else { 
       x = converter.StringToDouble(st.data(), st.size(), &processed_characters_count);
     }
-    if (processed_characters_count == 0) {
+    if (processed_characters_count == 0 && expect_error == false) {
       throw std::runtime_error("bug in findmax_doubleconversion");
     }
     answer = answer > x ? answer : x;
@@ -89,7 +89,7 @@ double findmax_doubleconversion(std::vector<std::basic_string<CharT>> &s) {
   return answer;
 }
 #ifdef _WIN32
-double findmax_strtod_16(std::vector<std::u16string>& s) {
+double findmax_strtod_16(std::vector<std::u16string>& s, bool expect_error) {
   double answer = 0;
   double x = 0;
   for (auto& st : s) {
@@ -97,7 +97,7 @@ double findmax_strtod_16(std::vector<std::u16string>& s) {
     static _locale_t c_locale = _create_locale(LC_ALL, "C");
     x = _wcstod_l((const wchar_t *)st.data(), &pr, c_locale);
 
-    if (pr == (const wchar_t*)st.data()) {
+    if (pr == (const wchar_t*)st.data() && expect_error == false) {
       throw std::runtime_error("bug in findmax_strtod");
     }
     answer = answer > x ? answer : x;
@@ -105,13 +105,13 @@ double findmax_strtod_16(std::vector<std::u16string>& s) {
   return answer;
 }
 #endif
-double findmax_netlib(std::vector<std::string> &s) {
+double findmax_netlib(std::vector<std::string> &s, bool expect_error) {
   double answer = 0;
   double x = 0;
   for (std::string &st : s) {
     char *pr = (char *)st.data();
     x = netlib_strtod(st.data(), &pr);
-    if (pr == st.data()) {
+    if (pr == st.data() && expect_error == false) {
       throw std::runtime_error(std::string("bug in findmax_netlib ")+st);
     }
     answer = answer > x ? answer : x;
@@ -120,13 +120,13 @@ double findmax_netlib(std::vector<std::string> &s) {
 }
 
 #ifdef ENABLE_RYU
-double findmax_ryus2d(std::vector<std::string> &s) {
+double findmax_ryus2d(std::vector<std::string> &s, bool expect_error) {
   double answer = 0;
   double x = 0;
   for (std::string &st : s) {
     // Ryu does not track character consumption (boo), but we can at least...
     Status stat = s2d(st.data(), &x);
-    if (stat != SUCCESS) {
+    if (stat != SUCCESS && expect_error == false) {
       throw std::runtime_error(std::string("bug in findmax_ryus2d ")+st + " " + std::to_string(stat));
     }
     answer = answer > x ? answer : x;
@@ -135,7 +135,7 @@ double findmax_ryus2d(std::vector<std::string> &s) {
 }
 #endif
 
-double findmax_strtod(std::vector<std::string> &s) {
+double findmax_strtod(std::vector<std::string> &s, bool expect_error) {
   double answer = 0;
   double x = 0;
   for (std::string &st : s) {
@@ -147,7 +147,7 @@ double findmax_strtod(std::vector<std::string> &s) {
     static locale_t c_locale = newlocale(LC_ALL_MASK, "C", NULL);
     x = strtod_l(st.data(), &pr, c_locale);
 #endif
-    if (pr == st.data()) {
+    if (pr == st.data() && expect_error == false) {
       throw std::runtime_error("bug in findmax_strtod");
     }
     answer = answer > x ? answer : x;
@@ -161,12 +161,12 @@ double findmax_strtod(std::vector<std::string> &s) {
 #endif
 
 #ifdef FROM_CHARS_AVAILABLE_MAYBE
-double findmax_from_chars(std::vector<std::string> &s) {
+double findmax_from_chars(std::vector<std::string> &s, bool expect_error) {
   double answer = 0;
   double x = 0;
   for (std::string &st : s) {
     auto [p, ec] = std::from_chars(st.data(), st.data() + st.size(), x);
-    if (p == st.data()) {
+    if (p == st.data() && expect_error == false) {
       throw std::runtime_error("bug in findmax_from_chars");
     }
     answer = answer > x ? answer : x;
@@ -176,12 +176,12 @@ double findmax_from_chars(std::vector<std::string> &s) {
 #endif
 
 template <typename CharT>
-double findmax_fastfloat(std::vector<std::basic_string<CharT>> &s) {
+double findmax_fastfloat(std::vector<std::basic_string<CharT>> &s, bool expect_error) {
   double answer = 0;
   double x = 0;
   for (auto &st : s) {
     auto [p, ec] = fast_float::from_chars(st.data(), st.data() + st.size(), x);
-    if (p == st.data()) {
+    if (p == st.data() && expect_error == false) {
       throw std::runtime_error("bug in findmax_fastfloat");
     }
     answer = answer > x ? answer : x;
@@ -190,12 +190,12 @@ double findmax_fastfloat(std::vector<std::basic_string<CharT>> &s) {
 }
 
 #ifndef __CYGWIN__
-double findmax_absl_from_chars(std::vector<std::string> &s) {
+double findmax_absl_from_chars(std::vector<std::string> &s, bool expect_error) {
   double answer = 0;
   double x = 0;
   for (std::string &st : s) {
     auto [p, ec] = absl::from_chars(st.data(), st.data() + st.size(), x);
-    if (p == st.data()) {
+    if (p == st.data() && expect_error == false) {
       throw std::runtime_error("bug in findmax_absl_from_chars");
     }
     answer = answer > x ? answer : x;
@@ -207,14 +207,14 @@ double findmax_absl_from_chars(std::vector<std::string> &s) {
 #ifdef USING_COUNTERS
 template <class T, class CharT>
 std::vector<event_count> time_it_ns(std::vector<std::basic_string<CharT>> &lines,
-                                     T const &function, size_t repeat) {
+                                     T const &function, size_t repeat, bool expect_error) {
   std::vector<event_count> aggregate;
   event_collector collector;
   bool printed_bug = false;
   for (size_t i = 0; i < repeat; i++) {
     collector.start();
-    double ts = function(lines);
-    if (ts == 0 && !printed_bug) {
+    double ts = function(lines,expect_error);
+    if (ts == 0 && !printed_bug && expect_error == false) {
       printf("bug\n");
       printed_bug = true;
     }
@@ -290,14 +290,14 @@ void pretty_print(double volume, size_t number_of_floats, std::string name, std:
 #else
 template <class T, class CharT>
 std::pair<double, double> time_it_ns(std::vector<std::basic_string<CharT>> &lines,
-                                     T const &function, size_t repeat) {
+                                     T const &function, size_t repeat, bool expect_error) {
   std::chrono::high_resolution_clock::time_point t1, t2;
   double average = 0;
   double min_value = DBL_MAX;
   bool printed_bug = false;
   for (size_t i = 0; i < repeat; i++) {
     t1 = std::chrono::high_resolution_clock::now();
-    double ts = function(lines);
+    double ts = function(lines, expect_error);
     if (ts == 0 && !printed_bug) {
       printf("bug\n");
       printed_bug = true;
@@ -348,35 +348,35 @@ std::vector<std::u16string> widen(const std::vector<std::string> &lines) {
 }
 
 
-void process(std::vector<std::string> &lines, size_t volume) {
+void process(std::vector<std::string> &lines, size_t volume, bool expect_error) {
   size_t repeat = 100;
   double volumeMB = volume / (1024. * 1024.);
   std::cout << "ASCII volume = " << volumeMB << " MB " << std::endl;
-  pretty_print(volume, lines.size(), "netlib", time_it_ns(lines, findmax_netlib, repeat));
-  pretty_print(volume, lines.size(), "doubleconversion", time_it_ns(lines, findmax_doubleconversion<char>, repeat));
-  pretty_print(volume, lines.size(), "strtod", time_it_ns(lines, findmax_strtod, repeat));
+  pretty_print(volume, lines.size(), "netlib", time_it_ns(lines, findmax_netlib, repeat, expect_error));
+  pretty_print(volume, lines.size(), "doubleconversion", time_it_ns(lines, findmax_doubleconversion<char>, repeat, expect_error));
+  pretty_print(volume, lines.size(), "strtod", time_it_ns(lines, findmax_strtod, repeat, expect_error));
 #ifdef ENABLE_RYU
-  pretty_print(volume, lines.size(), "ryu_parse", time_it_ns(lines, findmax_ryus2d, repeat));
+  pretty_print(volume, lines.size(), "ryu_parse", time_it_ns(lines, findmax_ryus2d, repeat, expect_error));
 #endif
 #ifndef __CYGWIN__
-  pretty_print(volume, lines.size(), "abseil", time_it_ns(lines, findmax_absl_from_chars, repeat));
+  pretty_print(volume, lines.size(), "abseil", time_it_ns(lines, findmax_absl_from_chars, repeat, expect_error));
 #endif
-  pretty_print(volume, lines.size(), "fastfloat", time_it_ns(lines, findmax_fastfloat<char>, repeat));
+  pretty_print(volume, lines.size(), "fastfloat", time_it_ns(lines, findmax_fastfloat<char>, repeat, expect_error));
 #ifdef FROM_CHARS_AVAILABLE_MAYBE
-  pretty_print(volume, lines.size(), "from_chars", time_it_ns(lines, findmax_from_chars, repeat));
+  pretty_print(volume, lines.size(), "from_chars", time_it_ns(lines, findmax_from_chars, repeat, expect_error));
 #endif
   std::vector<std::u16string> lines16 = widen(lines);
   volume = 2 * volume;
   volumeMB = volume / (1024. * 1024.);
   std::cout << "UTF-16 volume = " << volumeMB << " MB " << std::endl;
-  pretty_print(volume, lines.size(), "doubleconversion", time_it_ns(lines16, findmax_doubleconversion<char16_t>, repeat));
+  pretty_print(volume, lines.size(), "doubleconversion", time_it_ns(lines16, findmax_doubleconversion<char16_t>, repeat, expect_error));
 #ifdef _WIN32
-  pretty_print(volume, lines.size(), "wcstod", time_it_ns(lines16, findmax_strtod_16, repeat));
+  pretty_print(volume, lines.size(), "wcstod", time_it_ns(lines16, findmax_strtod_16, repeat, expect_error));
 #endif
-  pretty_print(volume, lines.size(), "fastfloat", time_it_ns(lines16, findmax_fastfloat<char16_t>, repeat));
+  pretty_print(volume, lines.size(), "fastfloat", time_it_ns(lines16, findmax_fastfloat<char16_t>, repeat, expect_error));
 }
 
-void fileload(const char *filename) {
+void fileload(const char *filename, bool expect_error) {
   std::ifstream inputfile(filename);
   if (!inputfile) {
     std::cerr << "can't open " << filename << std::endl;
@@ -391,7 +391,7 @@ void fileload(const char *filename) {
     lines.push_back(line);
   }
   std::cout << "# read " << lines.size() << " lines " << std::endl;
-  process(lines, volume);
+  process(lines, volume, expect_error);
 }
 
 
@@ -409,7 +409,7 @@ void parse_random_numbers(size_t howmany, bool concise, std::string random_model
     volume += line.size();
     lines.push_back(line);
   }
-  process(lines, volume);
+  process(lines, volume, false);
 }
 
 void parse_contrived(size_t howmany, const char *filename) {
@@ -431,7 +431,7 @@ void parse_contrived(size_t howmany, const char *filename) {
     for (size_t i = 0; i < howmany; i++) {
       lines.push_back(line);
     }
-    process(lines, volume);
+    process(lines, volume, false);
     lines.clear();
     std::cout << "-----------------------" << std::endl;
   }
@@ -448,8 +448,10 @@ int main(int argc, char **argv) {
         ("f,file", "File name.", cxxopts::value<std::string>()->default_value(""))
         ("v,volume", "Volume (number of floats generated).", cxxopts::value<size_t>()->default_value("100000"))
         ("m,model", "Random Model.", cxxopts::value<std::string>()->default_value("uniform"))
+        ("e,errors", "Enable testing of invalid inputs. inputs should come from -f/--file option.")
         ("h,help","Print usage.");
     auto result = options.parse(argc, argv);
+    bool test_errors = result["errors"].as<bool>();
     if(result["help"].as<bool>()) {
       std::cout << options.help() << std::endl;
       return EXIT_SUCCESS;
@@ -466,7 +468,7 @@ int main(int argc, char **argv) {
                    "string per line corresponding to a number"
                 << std::endl;
     } else {
-      fileload(filename.c_str());
+      fileload(filename.c_str(), test_errors);
     }
   } catch (const cxxopts::OptionException &e) {
     std::cout << "error parsing options: " << e.what() << std::endl;

--- a/data/generate_malformed.py
+++ b/data/generate_malformed.py
@@ -1,0 +1,51 @@
+import random
+import string
+
+
+# Generate malformed "numbers" with invalid formats
+def generate_malformed_numbers(num_lines):
+    malformed_numbers = []
+    for _ in range(num_lines):
+        # Create a random base string with digits and invalid symbols
+        base = "".join(random.choices(string.digits + ".eE", k=random.randint(5, 15)))
+
+        # Introduce guaranteed invalid structures:
+        # Randomly add multiple decimal points
+        for _ in range(random.randint(1, 3)):
+            pos = random.randint(0, len(base))
+            base = base[:pos] + "." + base[pos:]
+
+        # Randomly add misplaced 'e' or 'E'
+        for _ in range(random.randint(1, 2)):
+            pos = random.randint(0, len(base))
+            base = base[:pos] + random.choice("eE") + base[pos:]
+
+        # Randomly mix in letters or special characters
+        if random.random() < 0.5:
+            pos = random.randint(0, len(base))
+            base = (
+                base[:pos]
+                + random.choice(string.ascii_letters + "!@#$%^&*")
+                + base[pos:]
+            )
+
+        malformed_numbers.append(base)
+
+    return malformed_numbers
+
+
+# Save malformed "numbers" to a txt file
+def save_to_file(filename, malformed_numbers):
+    with open(filename, "w") as f:
+        for line in malformed_numbers:
+            f.write(line + "\n")
+
+
+# Generate and save
+random.seed(12345)
+num_lines = 1_000_000  # Number of malformed numbers to generate
+filename = "malformed_numbers.txt"
+malformed_numbers = generate_malformed_numbers(num_lines)
+save_to_file(filename, malformed_numbers)
+
+print(f"Generated {num_lines} malformed numbers and saved them to {filename}")


### PR DESCRIPTION

**Command-Line Interface Updates:**

- Added a new --errors flag to enable error testing for invalid inputs. If --errors is provided, invalid inputs are loaded from a file specified by -f/--file.
  - Added `malformed_numbers.txt` containing 1,000,000 malformed "numbers" for testing purposes.  

**Implementation details:**

- Modified logic to bypass exceptions for invalid inputs when expect_error is set to true.
- Updated all parsing functions (e.g., findmax_doubleconversion, findmax_strtod, findmax_netlib, etc.) to accept a new expect_error parameter.


**Sample results:**

```
root@hpe3:~/simple_fastfloat_benchmark# ./build/benchmarks/benchmark -f data/malformed_numbers.txt -e
# read 1000000 lines 
ASCII volume = 13.3548 MB 
netlib                                  :   418.68 MB/s (+/- 3.0 %)    31.35 Mfloat/s      10.96 i/B   153.50 i/f (+/- 0.0 %)      8.82 c/B   123.52 c/f (+/- 0.1 %)      1.24 i/c     30.33 b/f    309.07 bm/f      3.87 GHz 
doubleconversion                        :   272.10 MB/s (+/- 2.4 %)    20.37 Mfloat/s      22.40 i/B   313.68 i/f (+/- 0.0 %)     13.51 c/B   189.16 c/f (+/- 0.1 %)      1.66 i/c     63.71 b/f    329.99 bm/f      3.85 GHz 
strtod                                  :   213.13 MB/s (+/- 2.3 %)    15.96 Mfloat/s      28.77 i/B   402.94 i/f (+/- 0.0 %)     17.18 c/B   240.63 c/f (+/- 0.1 %)      1.67 i/c     82.84 b/f    348.90 bm/f      3.84 GHz 
abseil                                  :   294.40 MB/s (+/- 2.6 %)    22.04 Mfloat/s      20.82 i/B   291.57 i/f (+/- 0.0 %)     12.48 c/B   174.71 c/f (+/- 0.2 %)      1.67 i/c     63.69 b/f    280.60 bm/f      3.85 GHz 
fastfloat                               :   433.33 MB/s (+/- 3.1 %)    32.45 Mfloat/s      10.48 i/B   146.75 i/f (+/- 0.0 %)      8.53 c/B   119.42 c/f (+/- 0.1 %)      1.23 i/c     27.96 b/f    277.58 bm/f      3.87 GHz 
UTF-16 volume = 26.7097 MB 
doubleconversion                        :   555.05 MB/s (+/- 2.8 %)    20.78 Mfloat/s      11.32 i/B   317.13 i/f (+/- 0.0 %)      6.62 c/B   185.43 c/f (+/- 0.2 %)      1.71 i/c     67.03 b/f    331.43 bm/f      3.85 GHz 
fastfloat                               :   855.94 MB/s (+/- 2.8 %)    32.05 Mfloat/s       5.30 i/B   148.41 i/f (+/- 0.0 %)      4.31 c/B   120.71 c/f (+/- 0.2 %)      1.23 i/c     27.91 b/f    278.24 bm/f      3.87 GHz 
```

platform details:
```
Collection and Platform Info
    Application Command Line:	
    Operating System:	6.8.0-49-generic DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=22.04
DISTRIB_CODENAME=jammy
DISTRIB_DESCRIPTION="Ubuntu 22.04.5 LTS"
    CPU
        Name:	Intel(R) Xeon(R) Processor code named Cascadelake
        Frequency:	2.1 GHz
        Logical CPU Count:	20
        LLC size:	28.8 MB 
        Cache Allocation Technology
            Level 2 capability:	not detected
            Level 3 capability:	available
```