### PR TITLE
ffc.h: Remove clang ifdefs

### DIFF
--- a/benchmarks/benchmark.cpp
+++ b/benchmarks/benchmark.cpp
@@ -7,11 +7,9 @@
 #include "absl/strings/numbers.h"
 #endif
 #include "fast_float/fast_float.h"
-#ifdef __clang__
 extern "C" {
 #include "ffc.h"
 }
-#endif
 #ifdef ENABLE_RYU
 #include "ryu_parse.h"
 #endif
@@ -178,7 +176,6 @@ double findmax_absl_from_chars(std::vector<std::string> &s, bool expect_error) {
 }
 #endif
 
-#ifdef __clang__
 double findmax_ffc(std::vector<std::string> &s, bool expect_error) {
   double answer = 0;
   double x = 0;
@@ -191,7 +188,6 @@ double findmax_ffc(std::vector<std::string> &s, bool expect_error) {
   }
   return answer;
 }
-#endif
 
 #ifdef USING_COUNTERS
 template <class T, class CharT>
@@ -350,9 +346,7 @@ void process(std::vector<std::string> &lines, size_t volume, bool expect_error) 
   pretty_print(volume, lines.size(), "abseil", time_it_ns(lines, findmax_absl_from_chars, repeat, expect_error));
 #endif
   pretty_print(volume, lines.size(), "fastfloat", time_it_ns(lines, findmax_fastfloat<char>, repeat, expect_error));
-#ifdef __clang__
   pretty_print(volume, lines.size(), "ffc", time_it_ns(lines, findmax_ffc, repeat, expect_error));
-#endif
 #ifdef FROM_CHARS_AVAILABLE_MAYBE
   pretty_print(volume, lines.size(), "from_chars", time_it_ns(lines, findmax_from_chars, repeat, expect_error));
 #endif

--- a/benchmarks/benchmark32.cpp
+++ b/benchmarks/benchmark32.cpp
@@ -7,11 +7,9 @@
 #include "absl/strings/numbers.h"
 #endif
 #include "fast_float/fast_float.h"
-#ifdef __clang__
 extern "C" {
 #include "ffc.h"
 }
-#endif
 #ifdef ENABLE_RYU
 #include "ryu_parse.h"
 #endif
@@ -158,7 +156,6 @@ double findmax_absl_from_chars(std::vector<std::string> &s) {
 }
 #endif
 
-#ifdef __clang__
 double findmax_ffc(std::vector<std::string> &s) {
   double answer = 0;
   float x = 0;
@@ -171,7 +168,6 @@ double findmax_ffc(std::vector<std::string> &s) {
   }
   return answer;
 }
-#endif
 
 #ifdef USING_COUNTERS
 template <class T, class CharT>
@@ -316,9 +312,7 @@ void process(std::vector<std::string> &lines, size_t volume) {
   pretty_print(volume, lines.size(), "abseil", time_it_ns(lines, findmax_absl_from_chars, repeat));
 #endif
   pretty_print(volume, lines.size(), "fastfloat", time_it_ns(lines, findmax_fastfloat<char>, repeat));
-#ifdef __clang__
   pretty_print(volume, lines.size(), "ffc", time_it_ns(lines, findmax_ffc, repeat));
-#endif
 #ifdef FROM_CHARS_AVAILABLE_MAYBE
   pretty_print(volume, lines.size(), "from_chars", time_it_ns(lines, findmax_from_chars, repeat));
 #endif


### PR DESCRIPTION
Testing if this works; I compiled locally with gcc and it worked.

```
cmake -B build \
  -DCMAKE_C_COMPILER=gcc \
  -DCMAKE_CXX_COMPILER=g++ \
  -DCMAKE_BUILD_TYPE=Release
...
```